### PR TITLE
Several internal improvements, Clearer TypeError when providing an in…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,14 +22,16 @@ export enum RutFormat {
   DOTS_DASH,
 }
 
-export const formatRut = (rut: string, format = RutFormat.DASH): string => {
+export const formatRut = (rut?: string, format = RutFormat.DASH): string => {
+  if (rut === null || rut === undefined) return '';
+  if (typeof rut !== 'string') throw new TypeError('RUT needs to be a string or undefined');
   if (!isRutLike(rut)) return rut;
 
   switch (format) {
     case RutFormat.DOTS:
       return rut.replace(
         rutLikePattern(),
-        (...args) => `${args[1] ? `${args[1]}.` : ''}${args[2]}.${args[3]}${args[4]}`
+        (...m) => `${m[1] ? `${m[1]}.` : ''}${m[2]}.${m[3]}${m[4]}`
       );
 
     case RutFormat.DASH:
@@ -38,7 +40,7 @@ export const formatRut = (rut: string, format = RutFormat.DASH): string => {
     case RutFormat.DOTS_DASH:
       return rut.replace(
         rutLikePattern(),
-        (...args) => `${args[1] ? `${args[1]}.` : ''}${args[2]}.${args[3]}-${args[4]}`
+        (...m) => `${m[1] ? `${m[1]}.` : ''}${m[2]}.${m[3]}-${m[4]}`
       );
 
     default:
@@ -65,19 +67,23 @@ export const calculateRutVerifier = (digits: string): string => {
   return `${(11 - res)}`;
 };
 
-export const validateRut = (rut: string, noSuspicious = true): boolean => {
+export const validateRut = (rut?: string, noSuspicious = true): boolean => {
   if (!isRutLike(rut)) return false;
   if (noSuspicious && isSuspiciousRut(rut)) return false;
   return getRutVerifier(rut) === calculateRutVerifier(getRutDigits(rut));
 };
 
 type RutListResult = Map<string, boolean>;
-export const validateRutList = (ruts: string[], noSuspicious = true): RutListResult => {
-  return ruts.reduce<RutListResult>((result, rut) => {
-    result.set(rut, validateRut(rut, noSuspicious));
-    return result;
-  }, new Map<string, boolean>());
+export const validateRutList = (ruts: Iterable<string>, noSuspicious = true): RutListResult => {
+  const res = new Map<string, boolean>();
+
+  for(const rut of ruts) {
+    res.set(rut, validateRut(rut, noSuspicious));
+  }
+
+  return res;
 };
+
 
 export const generateRut = (): string => {
   // tslint:disable-next-line:insecure-random

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -1,3 +1,5 @@
+// tslint:disable-next-line:no-single-line-block-comment
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import {
   isRutLike,
   isSuspiciousRut,
@@ -15,7 +17,7 @@ import {
 
 describe('isRutLike', () => {
   it('Should validate Regex pattern for a rut-like string', () => {
-    const validCases: string[] = [
+    const validCases = [
       '9.999.999-9',
       '14355245-5',
       '34566754-k',
@@ -23,7 +25,7 @@ describe('isRutLike', () => {
       '32.456.356-k',
       '543.567-6',
     ];
-    const invalidCases: string[] = [
+    const invalidCases = [
       '23.432.432-t',
       'dfsg24rfr2f3-',
       '13.354322-g',
@@ -150,6 +152,28 @@ describe('validateRut', () => {
       expect(off).toEqual(false);
     });
   });
+
+  it('Should validate empty inputs', () => {
+    // @ts-ignore
+    expect(validateRut(false)).toEqual(false);
+    expect(validateRut(null)).toEqual(false);
+    expect(validateRut(undefined)).toEqual(false);
+  });
+
+  it('Should handle wrong input types properly', () => {
+    // @ts-ignore
+    expect(validateRut(0)).toEqual(false);
+    // @ts-ignore
+    expect(validateRut(['11'])).toEqual(false);
+    // @ts-ignore
+    expect(validateRut([0])).toEqual(false);
+    // @ts-ignore
+    expect(validateRut({})).toEqual(false);
+    // @ts-ignore
+    expect(validateRut({wot: 123})).toEqual(false);
+    // @ts-ignore
+    expect(validateRut()).toEqual(false);
+  });
 });
 
 describe('validateRutList', () => {
@@ -192,6 +216,35 @@ describe('formatRut', () => {
     expect(formatRut('900-000-000')).toEqual('900-000-000');
     expect(formatRut('19.234-321-422.34')).toEqual('19.234-321-422.34');
     expect(formatRut('')).toEqual('');
+    expect(formatRut(undefined)).toEqual('');
+    expect(formatRut(null)).toEqual('');
+    expect(formatRut()).toEqual('');
+  });
+  it('Should handle wrong input types properly', () => {
+    expect(() => {
+      // @ts-ignore
+      formatRut(false);
+    }).toThrowError('RUT needs to be a string or undefined');
+
+    expect(() => {
+      // @ts-ignore
+      formatRut(0);
+    }).toThrowError('RUT needs to be a string or undefined');
+
+    expect(() => {
+      // @ts-ignore
+      formatRut(['not', 'a', 'string']);
+    }).toThrowError('RUT needs to be a string or undefined');
+
+    expect(() => {
+      // @ts-ignore
+      formatRut(123355);
+    }).toThrowError('RUT needs to be a string or undefined');
+
+    expect(() => {
+      // @ts-ignore
+      formatRut({what: 123435});
+    }).toThrowError('RUT needs to be a string or undefined');
   });
 });
 


### PR DESCRIPTION
- Several internal improvements
- Clearer `TypeError.message` when providing an invalid input type to `formatRut`.
- Lots of more test cases.
- Changes Function signature of `validateRutList` so now it takes an `Iterable` instead of just an `array`, Internal implementation now free of `reduce`.